### PR TITLE
Update method for creating BoundBinaryOperator bindings

### DIFF
--- a/src/main/java/io/github/tdgog/compiler/Binder/Binary/BoundBinaryOperator.java
+++ b/src/main/java/io/github/tdgog/compiler/Binder/Binary/BoundBinaryOperator.java
@@ -1,8 +1,12 @@
 package io.github.tdgog.compiler.Binder.Binary;
 
 import io.github.tdgog.compiler.TreeParser.Syntax.SyntaxKind;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.HashMap;
 
 @Getter
 @RequiredArgsConstructor
@@ -22,46 +26,76 @@ public class BoundBinaryOperator {
         this(syntaxKind, operatorKind, operandType, operandType, resultType);
     }
 
-    private static final BoundBinaryOperator[] operators = {
-            // Integer only
-            new BoundBinaryOperator(SyntaxKind.PlusToken, BoundBinaryOperatorKind.Addition, Integer.class),
-            new BoundBinaryOperator(SyntaxKind.MinusToken, BoundBinaryOperatorKind.Subtraction, Integer.class),
-            new BoundBinaryOperator(SyntaxKind.MultiplyToken, BoundBinaryOperatorKind.Multiplication, Integer.class),
-            new BoundBinaryOperator(SyntaxKind.DivideToken, BoundBinaryOperatorKind.Division, Integer.class),
-            new BoundBinaryOperator(SyntaxKind.ModuloToken, BoundBinaryOperatorKind.Modulo, Integer.class),
-            new BoundBinaryOperator(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals, Integer.class, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, Integer.class, Boolean.class),
+    private static final ArrayList<BoundBinaryOperator> operators = new ArrayList<>();
 
-            // Double only
-            new BoundBinaryOperator(SyntaxKind.PlusToken, BoundBinaryOperatorKind.Addition, Double.class),
-            new BoundBinaryOperator(SyntaxKind.MinusToken, BoundBinaryOperatorKind.Subtraction, Double.class),
-            new BoundBinaryOperator(SyntaxKind.MultiplyToken, BoundBinaryOperatorKind.Multiplication, Double.class),
-            new BoundBinaryOperator(SyntaxKind.DivideToken, BoundBinaryOperatorKind.Division, Double.class),
-            new BoundBinaryOperator(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals, Double.class, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, Double.class, Boolean.class),
+    static {
+        @AllArgsConstructor
+        @Getter
+        final class TypeBindings {
+            private final Object primaryType;
+            private final Object[] secondaryTypes;
+            private final HashMap<SyntaxKind, BoundBinaryOperatorKind> boundKindLookup;
 
-            // Integer +-/* Double
-            new BoundBinaryOperator(SyntaxKind.PlusToken, BoundBinaryOperatorKind.Addition, Integer.class, Double.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.MinusToken, BoundBinaryOperatorKind.Subtraction, Integer.class, Double.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.MultiplyToken, BoundBinaryOperatorKind.Multiplication, Integer.class, Double.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.DivideToken, BoundBinaryOperatorKind.Division, Integer.class, Double.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals, Integer.class, Double.class, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, Integer.class, Double.class, Boolean.class),
+            public TypeBindings(Object primary, Object secondary, Object result, HashMap<SyntaxKind, BoundBinaryOperatorKind> boundKindLookup) {
+                this(primary, new Object[]{secondary}, boundKindLookup);
+            }
 
-            // Double +-/* Integer
-            new BoundBinaryOperator(SyntaxKind.PlusToken, BoundBinaryOperatorKind.Addition, Double.class, Integer.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.MinusToken, BoundBinaryOperatorKind.Subtraction, Double.class, Integer.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.MultiplyToken, BoundBinaryOperatorKind.Multiplication, Double.class, Integer.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.DivideToken, BoundBinaryOperatorKind.Division, Double.class, Integer.class, Double.class),
-            new BoundBinaryOperator(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals, Double.class, Integer.class, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, Double.class, Integer.class, Boolean.class),
+            public TypeBindings(Object primary, Object secondary, HashMap<SyntaxKind, BoundBinaryOperatorKind> boundKindLookup) {
+                this(primary, new Object[]{secondary}, primary, boundKindLookup);
+            }
 
-            // Boolean
-            new BoundBinaryOperator(SyntaxKind.DoublePipeToken, BoundBinaryOperatorKind.LogicalOr, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.DoubleAmpersandToken, BoundBinaryOperatorKind.LogicalAnd, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals, Boolean.class),
-            new BoundBinaryOperator(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals, Boolean.class),
-    };
+            public TypeBindings(Object primary, HashMap<SyntaxKind, BoundBinaryOperatorKind> boundKindLookup) {
+                this(primary, new Object[]{primary}, primary, boundKindLookup);
+            }
+        }
+
+        /* PRIMARY ---------------------> [SECONDARY]
+        *     |    defined operators for
+        *     |                |-------------> {SyntaxKind : BoundBinaryOperatorKind}
+        *     |                 in the format
+        *     |---------------------------------> RESULT_TYPE || PRIMARY
+        *      which have a result type equal to
+        * */
+        final TypeBindings[] bindings = new TypeBindings[] {
+                new TypeBindings(Integer.class, new HashMap<>() {{
+                    put(SyntaxKind.ModuloToken, BoundBinaryOperatorKind.Modulo);
+                    put(SyntaxKind.DivideToken, BoundBinaryOperatorKind.Division);
+                }}),
+                new TypeBindings(Double.class, Integer.class, new HashMap<>() {{
+                    put(SyntaxKind.PlusToken, BoundBinaryOperatorKind.Addition);
+                    put(SyntaxKind.MinusToken, BoundBinaryOperatorKind.Subtraction);
+                    put(SyntaxKind.MultiplyToken, BoundBinaryOperatorKind.Multiplication);
+                    put(SyntaxKind.DivideToken, BoundBinaryOperatorKind.Division);
+                }}),
+
+                /* TODO: There's lots of repetition here, find a way to update this to be more concise
+                *   Perhaps consider an option for all types in a TypeBinding to be considered primary
+                *   and therefore allow all permutations of typing as long as the result type is fixed */
+                new TypeBindings(Boolean.class, new Object[]{Integer.class, Double.class}, new HashMap<>() {{
+                    put(SyntaxKind.DoublePipeToken, BoundBinaryOperatorKind.LogicalOr);
+                    put(SyntaxKind.DoubleAmpersandToken, BoundBinaryOperatorKind.LogicalAnd);
+                    put(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals);
+                    put(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals);
+                }}),
+                new TypeBindings(Integer.class, Double.class, Boolean.class, new HashMap<>() {{
+                    put(SyntaxKind.DoublePipeToken, BoundBinaryOperatorKind.LogicalOr);
+                    put(SyntaxKind.DoubleAmpersandToken, BoundBinaryOperatorKind.LogicalAnd);
+                    put(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals);
+                    put(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals);
+                }}),
+                new TypeBindings(Double.class, Boolean.class, Boolean.class, new HashMap<>() {{
+                    put(SyntaxKind.DoublePipeToken, BoundBinaryOperatorKind.LogicalOr);
+                    put(SyntaxKind.DoubleAmpersandToken, BoundBinaryOperatorKind.LogicalAnd);
+                    put(SyntaxKind.DoubleEqualsToken, BoundBinaryOperatorKind.Equals);
+                    put(SyntaxKind.BangEqualsToken, BoundBinaryOperatorKind.NotEquals);
+                }}),
+        };
+
+        /* TODO: Walk through the bindings and add them to the operators list
+        *   Note that type bindings are NOT defined between secondaries - for example the
+        *   TypeBindings(Double.class, Integer.class, ...) will not define a binding for Integer + Integer, only
+        *   Double + Integer, Double + Double, and Integer + Double */
+    }
 
     public static BoundBinaryOperator bind(SyntaxKind syntaxKind, Object leftType, Object rightType) {
         for (BoundBinaryOperator operator : operators)


### PR DESCRIPTION
This method for creating BoundBinaryOperator bindings reduces repetition when working with larger quantities of datatypes and operators.